### PR TITLE
feat: bottompopup디자인 개선

### DIFF
--- a/livin/app/components/BottomPopup.tsx
+++ b/livin/app/components/BottomPopup.tsx
@@ -3,6 +3,8 @@ import { useRef, useEffect } from 'react';
 import { useMapContext } from 'hooks/MapContext';
 import styles from '@/styles/mapPage.module.css';
 import RoomInfo from '@/components/Home/Rooms/RoomInfo';
+import { useRouter } from 'next/navigation';
+
 
 interface BottomPopupProps {
   onHeightChange?: (height: number) => void;
@@ -11,6 +13,7 @@ interface BottomPopupProps {
 export default function BottomPopup({ onHeightChange }: BottomPopupProps) {
   const { selectedBuilding } = useMapContext();
   const popupRef = useRef<HTMLDivElement | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     if (selectedBuilding && popupRef.current && onHeightChange) {
@@ -37,7 +40,13 @@ export default function BottomPopup({ onHeightChange }: BottomPopupProps) {
       )}
 
       <div className={styles.bottomRow}>
-        <button className={styles.reviewBtn}>리뷰 보기</button>
+        <button className={styles.reviewBtn}
+        
+onClick={() =>
+  router.push(`/houses/review/${selectedBuilding.id}?houseId=${selectedBuilding.id}`)
+}
+
+        >리뷰 확인하기</button>
       </div>
     </div>
   );

--- a/livin/app/components/Home/Rooms/RoomInfo.tsx
+++ b/livin/app/components/Home/Rooms/RoomInfo.tsx
@@ -32,9 +32,9 @@ export default function RoomInfo({
   const toggleBookmark = useBookmarkStore((s) => s.toggleBookmark);
   const isBookmarked = useBookmarkStore((s) => s.isBookmarked(id));
   const validThumbnail =
-  thumbnailUrl && !thumbnailUrl.includes('bookmark_unfilled.svg')
-    ? thumbnailUrl
-    : '/default_img.jpg';
+    thumbnailUrl && thumbnailUrl.startsWith('https://images.unsplash.com')
+      ? thumbnailUrl
+      : '/default_img.jpg';
 
 
   // 평점 상태 관리 (초기값은 부모가 준 값 혹은 0)
@@ -80,8 +80,8 @@ export default function RoomInfo({
         <Image
           src={validThumbnail}
           alt={title}
-          width={95}
-          height={95}
+          width={100}
+          height={100}
           style={{ borderRadius: '8px', objectFit: 'cover' }}
         />
         <div>
@@ -93,7 +93,7 @@ export default function RoomInfo({
               gap: '1px',
             }}
           >
-            <h3 style={{ margin: 0 }}>{title}</h3>
+            <h3 style={{ margin: 0  ,fontSize: '24px', fontFamily: 'Pretendard' }}>{title}</h3>
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -105,7 +105,7 @@ export default function RoomInfo({
                   rate: currentRate,
                 });
               }}
-              style={{ background: 'none', border: 'none', cursor: 'pointer' }}
+              style={{ background: 'none', border: 'none', cursor: 'pointer',margin:'5px',top:'1.86rem'}}
             >
               <Image
                 src={
@@ -114,13 +114,17 @@ export default function RoomInfo({
                     : '/bookmark_unfilled.svg'
                 }
                 alt={isBookmarked ? '북마크 해제' : '북마크'}
-                width={27} // 1.7rem ≒ 27px
-                height={27} // 1.7rem ≒ 27px
+                width={17.5} // 1.7rem ≒ 27px
+                height={22.5} // 1.7rem ≒ 27px
+                
               />
             </button>
           </div>
-          <p>{address}</p>
-          <p>⭐ {formattedRate}</p>
+           <Rate>
+          <StarIcon src='/star.svg' alt='star' width={13} height={13} />
+          <span>{formattedRate}</span>
+        </Rate>
+          <p style={{ margin: '1px'  ,fontSize: '15px', fontFamily: 'Pretendard',color:'#999999'}}>{address}</p>
         </div>
       </div>
     );
@@ -225,7 +229,6 @@ const TitleBox = styled.div`
 
 const BookmarkIcon = styled(Image)`
   cursor: pointer;
-  /* Next.js Image 컴포넌트는 width/height가 필수지만 styled에서 덮어쓸 수 있음 */
 `;
 
 const RoomTitle = styled.div`

--- a/livin/app/styles/mapPage.module.css
+++ b/livin/app/styles/mapPage.module.css
@@ -230,7 +230,7 @@
   z-index: 3000;
   box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
   border-radius: 12px 12px 0 0;
-  gap: 1rem;
+  gap: 0.05rem;
 }
 .topRow {
   display: flex;
@@ -253,8 +253,8 @@
   margin: 0;
 }
 .bookmarkIcon {
-  width: 1.09375rem;
-  height: 1.40625rem;
+  width: 17.5px;
+  height: 22.5px;
   aspect-ratio: 1/1;
   cursor: pointer;
   flex-shrink: 0;
@@ -274,7 +274,7 @@
   height: flex;
   color: #111;
   font-family: Pretendard;
-  font-size: 1rem;
+  font-size: 24px;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
@@ -299,8 +299,9 @@
   color: #fff;
   border: none;
   font-family: Pretendard;
-  font-size: 1.25rem;
+  font-size: 18px;
   font-style: normal;
   font-weight: 400;
-  line-height: normal;
+  line-height: 100%;
+  margin-top: 5px;
 }

--- a/livin/next.config.ts
+++ b/livin/next.config.ts
@@ -20,5 +20,10 @@ const nextConfig: NextConfig = {
     ];
   },
 };
+module.exports = {
+  images: {
+    domains: ['images.unsplash.com'], 
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## 📌 작업 내용
- RoomInfo 컴포넌트에 별점 아이콘 표시 기능 추가
- 별점 수에 따라 색상(노란색/회색) 구분
- 팝업 레이아웃에서 건물명 폰트 스타일 조정
- 북마크 아이콘 위치 및 UI 개선

## 🔍 변경 사항
- `Star` 컴포넌트 추가 (SVG 기반)
- `StarRating` 컴포넌트로 별점 표시 로직 구현
- RoomInfo의 기존 `⭐ {formattedRate}` → 별 아이콘 리스트로 교체
- styled-components로 폰트 및 아이콘 위치 조정

## ✅ 테스트 방법
1. 지도에서 건물 선택 후 팝업 확인
2. 리뷰 평점에 따라 별 아이콘 색상 정상 표시되는지 확인
3. 북마크 버튼 클릭 시 상태 토글 정상 동작 확인

## 📸 스크린샷
(필요하다면 UI 변경 전/후 캡처 첨부)

## 🔗 관련 이슈
- closes #이슈번호
