### PR TITLE
fix: BottomPopup 라우팅 오류 수정

### DIFF
--- a/livin/app/components/BottomPopup.tsx
+++ b/livin/app/components/BottomPopup.tsx
@@ -4,7 +4,7 @@ import { useMapContext } from 'hooks/MapContext';
 import styles from '@/styles/mapPage.module.css';
 import RoomInfo from '@/components/Home/Rooms/RoomInfo';
 import { useRouter } from 'next/navigation';
-
+import { getHouseReviewsApi } from '@apis/house';
 
 interface BottomPopupProps {
   onHeightChange?: (height: number) => void;
@@ -40,13 +40,14 @@ export default function BottomPopup({ onHeightChange }: BottomPopupProps) {
       )}
 
       <div className={styles.bottomRow}>
-        <button className={styles.reviewBtn}
-        
-onClick={() =>
-  router.push(`/houses/review/${selectedBuilding.id}?houseId=${selectedBuilding.id}`)
-}
+        <button
+  className={styles.reviewBtn}
+  onClick={() => router.push(`/houses/${selectedBuilding.id}`)}
+>
+  리뷰 확인하기
+</button>
 
-        >리뷰 확인하기</button>
+
       </div>
     </div>
   );

--- a/livin/app/components/Home/Rooms/RoomInfo.tsx
+++ b/livin/app/components/Home/Rooms/RoomInfo.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 
 interface RoomInfoProps {
   id: number;
+  reviewId?: number;
   type: BuildingType;
   title: string;
   address: string;

--- a/livin/app/houses/[id]/page.tsx
+++ b/livin/app/houses/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import Image from 'next/image';
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams ,useSearchParams} from 'next/navigation';
 import HouseReviewCard from '@/components/House/HouseReviewCard';
 import FloatingWriteButton from '@/components/Common/FloatingWriteButton';
 import { getHouseReviewsApi, getHouseDetailApi } from '@apis/house';

--- a/livin/app/types/building.ts
+++ b/livin/app/types/building.ts
@@ -9,4 +9,5 @@ export interface Building {
   rate?: number;
   thumbnailUrl?: string;
   bookmarked?: boolean;
+  reviewId?: number;
 }


### PR DESCRIPTION
## PR 유형
- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
BottomPopup의 "리뷰 확인하기" 버튼을 건물 상세 페이지(/houses/:houseId)로 이동하도록 변경

건물 상세 페이지에서 리뷰 목록을 확인할 수 있도록 정상 동작 보장

## 이슈
<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->
resolves #
